### PR TITLE
Azure Pipelines Fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ steps:
   displayName: Installing Pester
   name: Dependencies
   
-- pwsh: Invoke-Pester -OutputFormat NUnitXML -OutputFile $(Build.ArtifactStagingDirectory)/Tests.XML
+- pwsh: Invoke-Pester -EnableExit -OutputFormat NUnitXML -OutputFile $(Build.ArtifactStagingDirectory)/Tests.XML
   displayName: Running tests
   name: Tests
 


### PR DESCRIPTION
Updates Azure Pipelines build configuration to cause CI build to fail if tests fail.